### PR TITLE
Add requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+libglib2.0-dev; sys_platform == "linux"
+bluepy; sys_platform == "linux"
+bleak; sys_platform != "linux"


### PR DESCRIPTION
Adding `requirements.txt` file with conditional requirements will simplify the installation and the management of project dependencies.

If added, both the Linux and Windows user can install required packages by using the following command:
```
pip3 install -r requirements.txt
```
This will only install packages that they require based on their system.

**_NOTE_**: 
- If added, you'll need to update the `README.md` install instructions.