### PR TITLE
Added Pwnagotchi support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,79 +1,70 @@
 <p align="center">
- <img src="https://github.com/K3YOMI/Wall-of-Flippers/assets/54733885/b524372d-17ef-4e2a-b6fb-ab4fccaaa643" alt="Wall of Flippers"></a>
+	<img src="https://github.com/K3YOMI/Wall-of-Flippers/assets/54733885/b524372d-17ef-4e2a-b6fb-ab4fccaaa643" alt="Wall of Flippers" />
 </p>
 
-
-
-
-
-<h1 style='font-size: 65px'; align="center">Wall of Flippers</h1>
+<h1 align="center">Wall of Flippers</h1>
 
 <div align="center">
   	<p align = "center">🐬 A simple and easy way to find Flipper Zero Devices and Bluetooth Low Energy Based Attacks 🐬</p>
   	<p align = "center">🐬 Documentation written by @k3yomi 🐬</p>
-	<div align="center" style="border: none;">
-		<table align="center" style="border-collapse: collapse; margin: 0 auto;">
+	<div align="center">
+		<table align="center">
 			<tr align="center">
 				<td align="center">
-					<a href="https://ko-fi.com/k3yomi" style="text-decoration: none;">
-						<img align="center" src='https://avatars.githubusercontent.com/u/54733885?s=55&v=4' width="55" height="55">
-						<img align="center" src='https://ko-fi.com/img/githubbutton_sm.svg'>
+					<a href="https://ko-fi.com/k3yomi">
+						<img align="center" src="https://avatars.githubusercontent.com/u/54733885?s=55&v=4" alt="avatar" width="55" height="55" />
+						<img align="center" src="https://ko-fi.com/img/githubbutton_sm.svg" alt="kofi" />
 					</a>
 					<h3 align="center">k3yomi (Project Maintainer)</h3>
 				</td>
 				<td align="center">
-					<a href="https://ko-fi.com/emilia0001" style="text-decoration: none;">
-						<img align="center" src='https://avatars.githubusercontent.com/u/37256246?s=55&v=4' width="55" height="55", style="border-radius: 50%;">
-						<img align="center" src='https://ko-fi.com/img/githubbutton_sm.svg'>
+					<a href="https://ko-fi.com/emilia0001">
+						<img align="center" src="https://avatars.githubusercontent.com/u/37256246?s=55&v=4" alt="avatar" width="55" height="55" />
+						<img align="center" src="https://ko-fi.com/img/githubbutton_sm.svg" alt="kofi" />
 					</a>
 					<h3 align="center">Emilia (jbohack) (Contributor)</h3>
 				</td>
 			</tr>
 		</table>
-		<img alt="GitHub Repo stars" src="https://img.shields.io/github/stars/K3YOMI/Wall-of-Flippers">
-		<img alt="GitHub forks" src="https://img.shields.io/github/forks/K3YOMI/Wall-of-Flippers">
-		<img alt="GitHub issues" src="https://img.shields.io/github/issues/K3YOMI/Wall-of-Flippers">
-		<img alt="GitHub pull requests" src="https://img.shields.io/github/issues-pr/K3YOMI/Wall-of-Flippers">
-		<a href="https://discord.gg/Bg2fvmjQvg" style="text-decoration: none;">
-			<img src="https://discord.com/api/guilds/1190160512953094235/widget.png?style=shield" alt="Discord Shield"/>
+		<img alt="GitHub Repo stars" src="https://img.shields.io/github/stars/K3YOMI/Wall-of-Flippers" />
+		<img alt="GitHub forks" src="https://img.shields.io/github/forks/K3YOMI/Wall-of-Flippers" />
+		<img alt="GitHub issues" src="https://img.shields.io/github/issues/K3YOMI/Wall-of-Flippers" />
+		<img alt="GitHub pull requests" src="https://img.shields.io/github/issues-pr/K3YOMI/Wall-of-Flippers" />
+		<a href="https://discord.gg/Bg2fvmjQvg">
+			<img src="https://discord.com/api/guilds/1190160512953094235/widget.png?style=shield" alt="Discord Shield" />
 		</a>
 	</div>
 </div>
 
-
 ---
+
 <div>
-    <img align="right" height="490vh" src="https://github.com/K3YOMI/Wall-of-Flippers/assets/54733885/a146acc6-7786-4406-b818-36a48b29473d">
-    <img align="right" height="490vh" src="https://upload.wikimedia.org/wikipedia/commons/3/3d/1_120_transparent.png">
+    <img align="right" height="490vh" src="https://github.com/K3YOMI/Wall-of-Flippers/assets/54733885/a146acc6-7786-4406-b818-36a48b29473d" alt="wof" />
 </div>
 
 # Table of Contents
-- [Introduction](#doc_introduction)
-- [Features](#doc_features)
-- [Videos](#doc_videos)
-- [Install Guide](#doc_install)
-  	- [How to install](#install_guides)
-    	- [Debian Linux Install](#debian_install)
-    	- [Fedora Install](#fedora_install)
-    	- [Arch Linux Install (SOON)](#arch_install)
-    	- [PinePhone Install (SOON)](#pinephone_install)
-    	- [Windows Install](#windows_install)
-    	- [Pwnagotchi Install](#pwnagotchi-install-guide)
-- [Issues and Fixes](#doc_issues_and_fixes)
-- [Common Errors and Fixes](#doc_c_and_e)
-- [Notice](#doc_statement)
-- [Credits and Packages](#doc_credits)
+- [Introduction](#-introduction)
+- [Features](#-current-features-and-future-updates)
+- [Videos and Articles](#-videos-and-articles)
+- [Install Guide](#-installing-and-requirements)
+  	- [How to install](#how-to-install)
+- [Issues and Fixes](#issues-and-fixes)
+- [Common Errors and Fixes](#common-errors-and-fixes)
+- [Notice](#notice)
+- [Contributors](#contributors)
+- [Credits](#credits)
 
-<br><br>
+<br />
+<br />
+<br />
+<br />
 
+# 🐬 Introduction
 
+Wall of Flippers (WoF) is a python based project involving the discovery of the Flipper Zero device and the identification of potential Bluetooth advertisment attacks. Please keep in mind that these two types of detections may **not** be related. Also the code is quite messy and not up to my standards. Will be updating and cleaning up some code in the future. Feel free to submit pull requests if you would like to contribute!
 
-# 🐬 Wall of Flippers? <a name = "doc_introduction"></a>
-> Wall of Flippers (WoF) is a python based project involving the discovery of the Flipper Zero device and the identification of potential Bluetooth advertisment attacks. Please keep in mind that these two types of detections may **not** be related. Also the code is quite messy and not up to my standards. Will be updating and cleaning up some code in the future. Feel free to submit pull requests if you would like to contribute!
+# 🐬 Current features and future updates
 
-
-
-# 🐬 Current features and future updates <a name = "doc_features"></a>
 - [x] Discover Flipper Zero Devices (Bluetooth must be enabled)
 - [X] Flipper Name Discovery
 - [X] Flipper Address Discovery
@@ -99,203 +90,254 @@
 	- [x] Linux Supported
  	- [ ] Windows Supported 	
 - [ ] Chromium Web Bluetooth Support
+- [ ] iOS/Android Detection (Pairing)
 - [ ] Animations (Looking for ascii artists)
 - [ ] ~Nuclear Fusion Implementation~
 
 
-# 🐬 Videos and Articles <a name = "doc_videos"></a>
+# 🐬 Videos and Articles
 
-<table align="center" style="border-collapse: collapse; margin: 0 auto;">
+<table align="center">
 	<tr align="center">
-		<td align="center">
-			<a href="https://www.youtube.com/watch?v=Pnw-uqd0GFM" style="text-decoration: none;">
-				<img align="center" src='https://i.ytimg.com/vi/Pnw-uqd0GFM/hqdefault.jpg?sqp=-oaymwEcCNACELwBSFXyq4qpAw4IARUAAIhCGAFwAcABBg==&rs=AOn4CLDEjuLtwBo0n-zRWhAKep7Raon5_Q' width="225" height="155">
+		<td align="center" width="49%">
+			<a href="https://www.youtube.com/watch?v=Pnw-uqd0GFM">
+				<img align="center" src="https://i.ytimg.com/vi/Pnw-uqd0GFM/hqdefault.jpg?sqp=-oaymwEcCNACELwBSFXyq4qpAw4IARUAAIhCGAFwAcABBg==&rs=AOn4CLDEjuLtwBo0n-zRWhAKep7Raon5_Q" width="225px" />
 			</a>
-			<h3 align="center">Talking Sasquach - Wall of Flippers Busts Flipper Zero BLE Spammers Red Handed!</h3>
 		</td>
-		<td align="center">
-			<a href="https://www.bleepingcomputer.com/news/security/wall-of-flippers-detects-flipper-zero-bluetooth-spam-attacks/" style="text-decoration: none;">
-				<img align="center" src='https://www.bleepstatic.com/content/hl-images/2023/01/03/flipper-zero.jpg' width="225" height="155", style="border-radius: 50%;">
+		<td align="center" width="49%">
+			<a href="https://www.bleepingcomputer.com/news/security/wall-of-flippers-detects-flipper-zero-bluetooth-spam-attacks/">
+				<img align="center" src="https://www.bleepstatic.com/content/hl-images/2023/01/03/flipper-zero.jpg" width="225px" />
 			</a>
-			<h3 align="center">BleepingComputer - ‘Wall of Flippers’ detects Flipper Zero Bluetooth spam attacks</h3>
+		</td>
+	</tr>
+	<tr>
+		<td align="center" width="49%">
+			<p align="center">Talking Sasquach - Wall of Flippers Busts Flipper Zero BLE Spammers Red Handed!</p>
+		</td>
+		<td align="center" width="49%">
+			<p align="center">BleepingComputer - ‘Wall of Flippers’ detects Flipper Zero Bluetooth spam attacks</p>
 		</td>
 	</tr>
 </table>
 
+# 🐬 Installing and Requirements
 
+A few things are required to properly run Wall of Flippers. We Recommend a Raspberry Pi as it's compact and portable! It's also required to have a `chipset` or a USB `adapter` that supports Bluetooth Low Energy. At this current time, there is `limited` support for Wall of Flippers on Windows. Hence we recommend using a linux based operating system as that has been used for testing and development. For BLE advertising, I recommened an external USB adapter as the internal adapter on the Raspberry Pi is not powerful enough to send BLE advertisments long range.  
 
-# 🐬 Installing and Requirements <a name = "doc_install"></a>
-
-> A few things are required to properly run Wall of Flippers. We Recommend a Raspberry Pi as it's compact and portable! It's also required to have a `chipset` or a USB `adapter` that supports Bluetooth Low Energy. At this current time, there is `limited` support for Wall of Flippers on Windows. Hence we recommend using a linux based operating system as that has been used for testing and development. For BLE advertising, I recommened an external USB adapter as the internal adapter on the Raspberry Pi is not powerful enough to send BLE advertisments long range.  
-
-
-
-## How to install <a name = "install_guides"></a>
-
-</details>
+## How to install
 
 <details>
-<summary> Debian Linux Install Guide </summary>
+<summary>Debian Linux Install Guide</summary>
 
+### Debian Linux Install Guide
 
-### Debian Linux Install Guide <a name = "debian_install"></a>
-> Wall of Flippers on debian linux is currently one of the best ways to run Wall of Flippers. Mostly due to it being stable and having a lot of support for BTLE. To start off, is is highly recommened to follow all instructions we provide unless you know what you are doing. To get started, we need to set up the directory and install the required packages.
+Wall of Flippers on debian linux is currently one of the best ways to run Wall of Flippers. Mostly due to it being stable and having a lot of support for BLE. To start off, it is highly recommened to follow all instructions we provide unless you know what you are doing. To get started, we need to set up the directory and install the required packages.
 
-### Step 1 (One): Full system upgrade / update
-> Before we continue with the installation, we need to make sure our system is up to date. To do this update through the command line.
+#### Step 1: Full system upgrade / update
 
-	sudo apt-get update && sudo apt-get upgrade -y
+Before we continue with the installation, we need to make sure our system is up to date. To do this update through the command line.
 
-### Step 2 (Two): Git Clone and Git Installiation 
-> To start off, we need to clone the repository and install the required packages. To do this, we need to run the following commands in the terminal. However, if you do not have git installed, you can simply install it by running this command (apt package manager only): 
+```sh
+sudo apt-get update && sudo apt-get upgrade -y
+```
 
-	sudo apt-get install git
-	git clone https://www.github.com/K3YOMI/Wall-of-Flippers
-	cd ./Wall-of-Flippers
+#### Step 2: Git Clone and Git Installation
 
-### Step 3 (Three): Installing python (python3)
-> Installing python3 is required to run wall of flippers and installs it's dependencies. The command below will install python3 for you. 
+To start off, we need to clone the repository and install the required packages. To do this, we need to run the following commands in the terminal. However, if you do not have git installed, you can simply install it by running this command (apt package manager only): 
 
-	sudo apt-get install python3
+```sh
+sudo apt-get install git
+git clone https://www.github.com/K3YOMI/Wall-of-Flippers
+cd ./Wall-of-Flippers
+```
 
-### Step 4 (Four): Setting up and Installing the required packages (Multiple Ways)
-> Installing the required packets and dependencies can be done in three ways with this install. You can choose to use the terminal with the commands below, use requirements.txt, or you use the easy install script within Wall of Flippers. The choice is up to you depending on your preference. To get started with the terminal way. We will use these commands below.
+#### Step 3: Installing python (python3)
 
-	sudo apt-get install libglib2.0-dev
- 	sudo apt-get install python3-bluez
-	python3 -m venv .venv
-	source .venv/bin/activate
-	################## PACKAGES ########################
-	# requirement.txt method
-	python3 -m pip install -r requirements.txt
-	# command method
-	python3 -m pip install bluepy
-	python3 -m pip install requests
- 	python3 -m pip install git+https://github.com/pybluez/pybluez.git#egg=pybluez#egg=pybluez
-	################## PACKAGES ########################
-	deactivate
-	
-> If you would like to use the easy install script, you can use the following commands below.
+Installing python3 is required to run wall of flippers and installs it's dependencies. The command below will install python3 for you. 
 
-	bash wof.sh
-	# You should get a prompt upon startup, about setting up a managed environment, feel free to let it do for you. Then once an environemnet is complete run `wof.sh` again
-	and press 4 for the auto install process.
+```sh
+sudo apt-get install python3
+```
 
-### Step 5 (Five): Running Wall of Flippers
-> Once you have finished with all the dependencies and requirements, you can now run Wall of Flippers. To do this, you can run the following command below.
+#### Step 4: Setting up and Installing the required packages (Multiple Ways)
 
-	bash wof.sh
+Installing the required packets and dependencies can be done in three ways with this install. You can choose to use the terminal with the commands below, use requirements.txt, or you use the easy install script within Wall of Flippers. The choice is up to you depending on your preference. To get started with the terminal way. We will use these commands below.
 
-> Please keep note that running Wall of Flippers requires elevated privileges. Hence the `sudo` command. If you do not want to run Wall of Flippers with elevated privileges, you can run the following command below.
+```sh
+sudo apt-get install libglib2.0-dev
+sudo apt-get install python3-bluez
+python3 -m venv .venv
+source .venv/bin/activate
 
-	sudo chmod +x WallofFlippers.py
-	./WallofFlippers.py
- </details>
- <details>
-<summary> Fedora Linux Install Guide </summary>
+################## PACKAGES ########################
+# requirement.txt method
+python3 -m pip install -r requirements.txt
+# command method
+python3 -m pip install bluepy
+python3 -m pip install requests
+python3 -m pip install git+https://github.com/pybluez/pybluez.git#egg=pybluez
+################## PACKAGES ########################
+
+deactivate
+```
+
+If you would like to use the easy install script, you can use the following commands below.
+
+```sh
+bash wof.sh
+```
+
+You should get a prompt upon startup, about setting up a managed environment, feel free to let it do for you. Then once an environemnet is complete run `wof.sh` again and press 4 for the auto install process.
+
+#### Step 5: Running Wall of Flippers
+
+Once you have finished with all the dependencies and requirements, you can now run Wall of Flippers. To do this, you can run the following command below.
+
+```sh
+bash wof.sh
+```
+
+Please keep note that running Wall of Flippers requires elevated privileges. Hence the `sudo` command. If you do not want to run Wall of Flippers with elevated privileges, you can run the following command below.
+
+```sh
+sudo chmod +x WallofFlippers.py
+./WallofFlippers.py
+```
+
+</details>
+ 
+<details>
+<summary>Fedora Linux Install Guide</summary>
 	 
-### Fedora Install Guide <a name = "fedora_install"></a>
-> To start off, is is highly recommened to follow all instructions we provide unless you know what you are doing. To get started, we need to set up the directory and install the required packages.
+### Fedora Install Guide
 
-### Step 1 (One): Full system upgrade / update
-> Before we continue with the installation, we need to make sure our system is up to date. To do this update through the command line.
+To start off, is is highly recommened to follow all instructions we provide unless you know what you are doing. To get started, we need to set up the directory and install the required packages.
 
-	sudo dnf update && sudo dnf upgrade -y
-### Step 2 (Two): Git Clone and Git Installiation 
-> To start off, we need to clone the repository and install the required packages. To do this, we need to run the following commands in the terminal. However, if you do not have git installed, you can simply install it by running this command (apt package manager only): 
+#### Step 1: Full system upgrade / update
 
-	sudo dnf install git
-	git clone https://www.github.com/K3YOMI/Wall-of-Flippers
-	cd ./Wall-of-Flippers
+Before we continue with the installation, we need to make sure our system is up to date. To do this update through the command line.
 
-### Step 3 (Three): Installing python (python3)
-> Installing python3 is required to run wall of flippers and installs it's dependencies. The command below will install python3 for you. 
+```sh
+sudo dnf update && sudo dnf upgrade -y
+```
 
-	sudo dnf install python3
+#### Step 2: Git Clone and Git Installation 
 
-### Step 4 (Four): Setting up and Installing the required packages (Multiple Ways)
-> Installing the required packets and dependencies can be done in three ways with this install. You can choose to use the terminal with the commands below, use requirements.txt, or you use the easy install script within Wall of Flippers. The choice is up to you depending on your preference. To get started with the terminal way. We will use these commands below.
+To start off, we need to clone the repository and install the required packages. To do this, we need to run the following commands in the terminal. However, if you do not have git installed, you can simply install it by running this command (apt package manager only): 
 
-	sudo dnf install glib2-devel
- 	sudo dnf install python3-bluez
-	python3 -m venv .venv
-	source .venv/bin/activate
-	################## PACKAGES ########################
-	# requirement.txt method
-	python3 -m pip install -r requirements.txt
-	# command method
-	python3 -m pip install bluepy
-	python3 -m pip install requests
- 	python3 -m pip install git+https://github.com/pybluez/pybluez.git#egg=pybluez#egg=pybluez
-	################## PACKAGES ########################
-	deactivate
+```sh
+sudo dnf install git
+git clone https://www.github.com/K3YOMI/Wall-of-Flippers
+cd ./Wall-of-Flippers
+```
 
-> If you would like to use the easy install script, you can use the following commands below.
+#### Step 3: Installing python (python3)
 
-	bash wof.sh
-	# You should get a prompt upon startup, about setting up a managed environment, feel free to let it do for you. Then once an environemnet is complete run `wof.sh` again
-	and press 4 for the auto install process.
+Installing python3 is required to run wall of flippers and installs it's dependencies. The command below will install python3 for you. 
 
-### Step 5 (Five): Running Wall of Flippers
-> Once you have finished with all the dependencies and requirements, you can now run Wall of Flippers. To do this, you can run the following command below.
+```sh
+sudo dnf install python3
+```
 
-	bash wof.sh
+#### Step 4: Setting up and Installing the required packages (Multiple Ways)
 
-> Please keep note that running Wall of Flippers requires elevated privileges. Hence the `sudo` command. If you do not want to run Wall of Flippers with elevated privileges, you can run the following command below.
+Installing the required packets and dependencies can be done in three ways with this install. You can choose to use the terminal with the commands below, use requirements.txt, or you use the easy install script within Wall of Flippers. The choice is up to you depending on your preference. To get started with the terminal way. We will use these commands below.
 
-	sudo chmod +x WallofFlippers.py
-	./WallofFlippers.py
+```sh
+sudo dnf install glib2-devel
+sudo dnf install python3-bluez
+python3 -m venv .venv
+source .venv/bin/activate
 
+################## PACKAGES ########################
+# requirement.txt method
+python3 -m pip install -r requirements.txt
+# command method
+python3 -m pip install bluepy
+python3 -m pip install requests
+python3 -m pip install git+https://github.com/pybluez/pybluez.git#egg=pybluez
+################## PACKAGES ########################
+
+deactivate
+```
+
+If you would like to use the easy install script, you can use the following commands below.
+
+```sh
+bash wof.sh
+```
+
+You should get a prompt upon startup, about setting up a managed environment, feel free to let it do for you. Then once an environemnet is complete run `wof.sh` again and press 4 for the auto install process.
+
+#### Step 5: Running Wall of Flippers
+
+Once you have finished with all the dependencies and requirements, you can now run Wall of Flippers. To do this, you can run the following command below.
+
+```sh
+bash wof.sh
+```
+
+Please keep note that running Wall of Flippers requires elevated privileges. Hence the `sudo` command. If you do not want to run Wall of Flippers with elevated privileges, you can run the following command below.
+
+```sh
+sudo chmod +x WallofFlippers.py
+./WallofFlippers.py
+```
 
 </details>
 
 <details>
-<summary> Windows Install Guide </summary>
+<summary>Windows Install Guide</summary>
 
-## Windows Install Guide <a name = "windows_install"></a>
-> Windows is currently not fully supported. However, you can still run Wall of Flippers on Windows. A few missing features like the ability to detect advertisment attacks and ability to send advertisments. However the detection of the Flipper Zero device is still supported. To get started, we will need to clone the repository and install the required packages. To do this, we need to run the following commands in the command prompt. However, if you do not have git installed, you can simply install it by downloading it from the official website.
+### Windows Install Guide
 
-### Step 1 (One): Git Clone and Git Installiation 
+Windows is currently not fully supported. However, you can still run Wall of Flippers on Windows. A few missing features like the ability to detect advertisment attacks and ability to send advertisments. However the detection of the Flipper Zero device is still supported.
 
+To get started, we will need to clone the repository and install the required packages. To do this, we need to run the following commands in the command prompt. However, if you do not have git installed, you can simply install it by downloading it from the official website.
 
-	Download Link: https://git-scm.com/downloads
+#### Step 1: Git Clone and Git Installation 
 
-> Once you have downloaded git, you can now run the following commands below.
+Download and install `git` from [here](https://git-scm.com/downloads). Once you have downloaded it, you can now run the following commands below.
 
-	git clone https://www.github.com/K3YOMI/Wall-of-Flippers
-	cd ./Wall-of-Flippers
+```powershell
+git clone https://www.github.com/K3YOMI/Wall-of-Flippers
+cd ./Wall-of-Flippers
+```
 
+#### Step 2: Installing python and pip (python / pip)
 
-### Step 2 (Two): Installing python and pip (python / pip)
-> This step is quite straightforward as we will be installing python and pip. To do this, we will need to download the latest version of python from the official website. Once you have downloaded the installer, you can run it and install python. Please make sure to check the box that says `Add Python to PATH`. This will allow you to run python from the command prompt. Once you have installed python, you can now install the required packages. 
+This step is quite straightforward as we will be installing python and pip. To do this, we will need to download the latest version of python from the [official website](https://www.python.org/downloads/). Once you have downloaded the installer, you can run it and install python. Please make sure to check the box that says `Add Python to PATH`. This will allow you to run python from the command prompt. Once you have installed python, you can now install the required packages. To do this, we will need to run the following commands below.
 
-	Download Link: https://www.python.org/downloads/
+```powershell
+pip install bleak
+pip install requests
+```
 
-> Once you have installed python, you can now install the required packages. To do this, we will need to run the following commands below.
+Alternatively, you can use the requirements.txt file to install the required packages. To do this, we will need to run the following commands below.
 
-	pip install bleak
-	pip install requests
+```powershell
+pip install -r requirements.txt
+```
 
+If you would like to use the easy install script, you can use the following commands below.
 
-> Alternatively, you can use the requirements.txt file to install the required packages. To do this, we will need to run the following commands below.
+```powershell
+python WallofFlippers.py
+```
 
-	pip install -r requirements.txt
+You should get a prompt upon startup, press 4 for the easy install and follow the directions and prompts for the install.
 
-> If you would like to use the easy install script, you can use the following commands below.
+*If you are having issues with pip being not recognized as a command, please refer to [this](https://stackoverflow.com/questions/23708898/pip-is-not-recognized-as-an-internal-or-external-command) question on Stack Overflow.*
 
-	python WallofFlippers.py
-	# You should get a prompt upon startup, press 4 for the easy install and follow the directions and prompts for the install.
+#### Step 3: Running Wall of Flippers
 
-> If you are having issues with pip being not recognized as a command, please refer to this question below:\
-https://stackoverflow.com/questions/23708898/pip-is-not-recognized-as-an-internal-or-external-command
+Once you have finished with all the dependencies and requirements, you can now run Wall of Flippers. To do this, you can run the following command below.
 
-### Step 3 (Three): Running Wall of Flippers
-> Once you have finished with all the dependencies and requirements, you can now run Wall of Flippers. To do this, you can run the following command below.
-
-	python WallofFlippers.py
+```powershell
+python WallofFlippers.py
+```
 	
-> Please keep note that this is a watered down version of Wall of Flippers. Hence the lack of features. If you would like to run the full version of Wall of Flippers, please refer to the Linux Install Guide above.
-
+Please keep note that this is a watered down version of Wall of Flippers. Hence the lack of features. If you would like to run the full version of Wall of Flippers, please refer to the Linux Install Guide above.
 
 </details>
 
@@ -303,22 +345,29 @@ https://stackoverflow.com/questions/23708898/pip-is-not-recognized-as-an-interna
 <summary>Pwnagotchi Install Guide</summary>
 
 ### Pwnagotchi Install Guide
-> You can run Wall of Flippers on Pwnagotchi to scan and save flippers data that your little friend find near them.
 
-#### Step 1 (One): Clone the repo
-> Login as `root` on your Pwnagotchi and run:
-```shell
+You can run Wall of Flippers on Pwnagotchi to scan and save flippers data that your little friend finds near them.
+
+#### Step 1: Clone the repo
+
+Login as `root` on your Pwnagotchi and run:
+
+```sh
 cd /root && git clone https://www.github.com/K3YOMI/Wall-of-Flippers && cd Wall-of-Flippers
 ```
 
-#### Step 2 (Two): Install Python dependencies
-> Create virtual environment and install Python dependencies.
-``` shell
+#### Step 2: Install Python dependencies
+
+Create virtual environment and install Python dependencies.
+
+``` sh
 python3 -m venv .venv && source .venv/bin/activate && pip install -r requirements.txt && deactivate
 ```
 
-#### Step 3 (Three): Systemd daemon
-> Create the systemd service in `/etc/systemd/system/wof.service`.
+#### Step 3: Systemd daemon
+
+Create the systemd service in `/etc/systemd/system/wof.service`.
+
 ```
 [Unit]
 Description=WallofFlippers - A simple and easy way to find Flipper Zero Devices and Bluetooth Low Energy Based Attacks
@@ -337,63 +386,78 @@ Environment="PYTHONUNBUFFERED=1"
 WantedBy=multi-user.target
 ```
 
-> Then run:
-```
+Then run:
+
+```sh
 systemctl daemon-reload
 ```
 
-#### Step 4 (Four): Start daemon
-> To start Wall of Flippers daemon, run:
-```
+#### Step 4: Start daemon
+
+To start Wall of Flippers daemon, run:
+
+```sh
 systemctl start wof
 ```
 
-> If you want to start the daemon on boot, run:
-```
+If you want to start the daemon on boot, run:
+
+```sh
 systemctl enable wof
 ```
 
-> Once you start the daemon, Wall of Flippers should be running and scanning for nearby Flippers. You can check the status by running:
-```
+Once you start the daemon, Wall of Flippers should be running and scanning for nearby Flippers. You can check the status by running:
+
+```sh
 systemctl status wof
 ```
 
-#### Step 5 (Five): Install plugin (optional)
+#### Step 5: Install plugin (optional)
 
-> If you want to see the data of Wall of Flippers on you Pwnagotchi screen, install CyberArtemio's `wof-pwnagotchi-plugin`. Follow the installation steps [here](https://github.com/cyberartemio/wof-pwnagotchi-plugin#-installation).
+If you want to see the data of Wall of Flippers on your Pwnagotchi screen and on its web UI, install CyberArtemio's `wof-pwnagotchi-plugin`. Follow the installation steps [here](https://github.com/cyberartemio/wof-pwnagotchi-plugin#-installation).
 
 </details>
 
-# Issues and Fixes <a name = "doc_issues_and_fixes"></a>
+# Issues and Fixes
 
-> If you encounter any issues or bugs, please report them to us on our github page. We will try our best to fix them as soon as possible. If you would like to contribute to the project, please feel free to make a pull request. We will review it and merge it if it is a good addition to the project. We will be starting a discord server soon for support and development. Please keep an eye out for that. Thank you for your support and we hope you enjoy this project! <3
-
-
-# Common Errors and Fixes <a name = "doc_c_and_e"></a>
-### No such file or directory /sys/class/bluetooth
-> If the `/sys/class/bluetooth` directory is not present on your system, it may indicate that the Bluetooth subsystem is not properly detected or enabled. To check if you have the right hardware, please run 
-
-	sudo service bluetooth status
-
-> If the status is `dead` you may not have a valid bluetooth chipset or adapter present. If `inactive`, you can enable the service using this command
-
-	sudo service bluetooth restart
+If you encounter any issues or bugs, please report them to us on our github page. We will try our best to fix them as soon as possible. If you would like to contribute to the project, please feel free to make a pull request. We will review it and merge it if it is a good addition to the project. We will be starting a discord server soon for support and development. Please keep an eye out for that. Thank you for your support and we hope you enjoy this project! <3
 
 
+# Common Errors and Fixes
 
+### No such file or directory `/sys/class/bluetooth`
 
-# Notice <a name = "doc_statement"></a>
-> This project isn't the solution to combat the Flipper Zero device or any form of btle attacks. **THIS DOES NOT MITIGATE OR STOP ANYTHING**!!! However, the flipper zero device is a great tool for learning and understanding the inctracies of the cyberworld. Now for the detections for this project, we heavily rely on the advertisments that the Flipper Zero sends out for detection. While a user can do many things to avoid being detected by Wall of Flippers. (Depending if the Identifier method gets worked around) We highly advise using this project for an end all solution. While not all bluetooth attacks are sent from only the flipper, it's a good start to understand the world of bluetooth and the attacks that can be accomplished with simple devices. We hope you enjoy this project and we hope you take the time to learn and build off of this. We are always looking for contributions and new ideas. Thank you for looking at this project and we hope you enjoy it! -k3yomi and emilia0001
+If the `/sys/class/bluetooth` directory is not present on your system, it may indicate that the Bluetooth subsystem is not properly detected or enabled. To check if you have the right hardware, please run:
 
+```sh
+sudo service bluetooth status
+```
 
+If the status is `dead` you may not have a valid bluetooth chipset or adapter present. If `inactive`, you can enable the service using this command
 
+```sh
+sudo service bluetooth restart
+```
 
+# Notice
 
+> This project isn't the solution to combat the Flipper Zero device or any form of BLE attacks. **THIS DOES NOT MITIGATE OR STOP ANYTHING**!!! However, the flipper zero device is a great tool for learning and understanding the inctracies of the cyberworld. Now for the detections for this project, we heavily rely on the advertisments that the Flipper Zero sends out for detection. While a user can do many things to avoid being detected by Wall of Flippers. (Depending if the Identifier method gets worked around) We highly advise using this project for an end all solution. While not all bluetooth attacks are sent from only the flipper, it's a good start to understand the world of bluetooth and the attacks that can be accomplished with simple devices.
+> 
+> We hope you enjoy this project and we hope you take the time to learn and build off of this. We are always looking for contributions and new ideas. Thank you for looking at this project and we hope you enjoy it!
+> 
+> *k3yomi and emilia0001*
 
-# Contributors and Credits <a name = "doc_credits"></a>
-> This project was made possible by the following people. Please make sure to check them out and support them! <3
+# Contributors
 
-| Project Maintainer | Project Contributor | AppleJuice BLE Advertisment Data |
-| --- | --- | --- |
-| ![k3yomi](https://avatars.githubusercontent.com/u/54733885?s=55&v=4) | ![emilia0001](https://avatars.githubusercontent.com/u/37256246?s=55&v=4) | ![ecto-1a](https://avatars.githubusercontent.com/u/112792126?s=55&v=4)
-| k3yomi | emilia0001 | Ecto-1A |
+This project was made possible by the following people. Please make sure to check them out and support them! <3
+
+[<img alt="K3YOMI" src="https://avatars.githubusercontent.com/u/54733885?v=4&s=55" width="55">](https://github.com/K3YOMI) |[<img alt="nescapp" src="https://avatars.githubusercontent.com/u/97590612?v=4&s=55" width="55">](https://github.com/nescapp) |[<img alt="jbohack" src="https://avatars.githubusercontent.com/u/37256246?v=4&s=55" width="55">](https://github.com/jbohack) |[<img alt="OnlyNandan" src="https://avatars.githubusercontent.com/u/78302872?v=4&s=55" width="55">](https://github.com/OnlyNandan) |[<img alt="cyberartemio" src="https://avatars.githubusercontent.com/u/156206062?v=4&s=55" width="55">](https://github.com/cyberartemio) |[<img alt="AleksaMCode" src="https://avatars.githubusercontent.com/u/23129943?v=4&s=55" width="55">](https://github.com/AleksaMCode) |[<img alt="elliotwutingfeng" src="https://avatars.githubusercontent.com/u/30223404?v=4&s=55" width="55">](https://github.com/elliotwutingfeng) |
+:---: |:---: |:---: |:---: |:---: |:---: |:---: |
+[K3YOMI](https://github.com/K3YOMI) |[nescapp](https://github.com/nescapp) |[jbohack](https://github.com/jbohack) |[OnlyNandan](https://github.com/OnlyNandan) |[cyberartemio](https://github.com/cyberartemio) |[AleksaMCode](https://github.com/AleksaMCode) |[elliotwutingfeng](https://github.com/elliotwutingfeng) |
+
+# Credits
+
+AppleJuice BLE Advertisment Data |
+:---: |
+[<img alt="ecto-1a" src="https://avatars.githubusercontent.com/u/112792126" width="55">](https://github.com/ECTO-1A) |
+[ECTO-1A](https://github.com/ECTO-1A)|

--- a/README.md
+++ b/README.md
@@ -324,7 +324,8 @@ python3 -m venv .venv && source .venv/bin/activate && pip install -r requirement
 Description=WallofFlippers - A simple and easy way to find Flipper Zero Devices and Bluetooth Low Energy Based Attacks
 
 [Service]
-ExecStart=/root/Wall-of-Flippers/.venv/bin/python /root/Wall-of-Flippers/WallofFlippers.py wof -d 0
+ExecStart=/root/Wall-of-Flippers/.venv/bin/python /root/Wall-of-Flippers/WallofFlippers.py --no-ui wof -d 0
+WorkingDirectory=/root/Wall-of-Flippers/
 StandardOutput=syslog
 StandardError=syslog
 SyslogIdentifier=wof

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@
     	- [Fedora Install](#fedora_install)
     	- [Arch Linux Install (SOON)](#arch_install)
     	- [PinePhone Install (SOON)](#pinephone_install)
-  	    - [Windows Install](#windows_install)
-		- [Pwnagotchi](#pwnagotchi)
+    	- [Windows Install](#windows_install)
+    	- [Pwnagotchi Install](#pwnagotchi-install-guide)
 - [Issues and Fixes](#doc_issues_and_fixes)
 - [Common Errors and Fixes](#doc_c_and_e)
 - [Notice](#doc_statement)
@@ -300,24 +300,25 @@ https://stackoverflow.com/questions/23708898/pip-is-not-recognized-as-an-interna
 </details>
 
 <details>
-<summary>Pwnagotchi</summary>
+<summary>Pwnagotchi Install Guide</summary>
 
-### Pwnagotchi
-You can run Wall of Flippers on Pwnagotchi to scan and save flippers data that your little friend find near them.
+### Pwnagotchi Install Guide
+> You can run Wall of Flippers on Pwnagotchi to scan and save flippers data that your little friend find near them.
 
-#### Step 1: Clone the repo
-Login as `root` on your Pwnagotchi and run:
-```
+#### Step 1 (One): Clone the repo
+> Login as `root` on your Pwnagotchi and run:
+```shell
 cd /root && git clone https://www.github.com/K3YOMI/Wall-of-Flippers && cd Wall-of-Flippers
 ```
 
-#### Step 2: Install Python dependencies
-```
-python3 -m venv .venv && source .venv/bin/activate && pip install -r requirements.txt
+#### Step 2 (Two): Install Python dependencies
+> Create virtual environment and install Python dependencies.
+``` shell
+python3 -m venv .venv && source .venv/bin/activate && pip install -r requirements.txt && deactivate
 ```
 
-#### Step 3: Systemd daemon
-Create the systemd service in `/etc/systemd/system/wof.service` and add:
+#### Step 3 (Three): Systemd daemon
+> Create the systemd service in `/etc/systemd/system/wof.service`.
 ```
 [Unit]
 Description=WallofFlippers - A simple and easy way to find Flipper Zero Devices and Bluetooth Low Energy Based Attacks
@@ -335,30 +336,30 @@ Environment="PYTHONUNBUFFERED=1"
 WantedBy=multi-user.target
 ```
 
-Then run:
+> Then run:
 ```
 systemctl daemon-reload
 ```
 
-#### Step 4: Start daemon
-To start Wall of Flippers daemon, run:
+#### Step 4 (Four): Start daemon
+> To start Wall of Flippers daemon, run:
 ```
 systemctl start wof
 ```
 
-If you want to start the daemon on boot, run:
+> If you want to start the daemon on boot, run:
 ```
 systemctl enable wof
 ```
 
-Once you start the daemon, Wall of Flippers should be running and scanning for nearby Flippers. You can check the status by running:
+> Once you start the daemon, Wall of Flippers should be running and scanning for nearby Flippers. You can check the status by running:
 ```
 systemctl status wof
 ```
 
-#### Step 5: Install plugin (optional)
+#### Step 5 (Five): Install plugin (optional)
 
-If you want to see the data of Wall of Flippers on you Pwnagotchi screen, install CyberArtemio's `wof-pwnagotchi-plugin`. Follow the installation steps [here](https://github.com/cyberartemio/wof-pwnagotchi-plugin#-installation).
+> If you want to see the data of Wall of Flippers on you Pwnagotchi screen, install CyberArtemio's `wof-pwnagotchi-plugin`. Follow the installation steps [here](https://github.com/cyberartemio/wof-pwnagotchi-plugin#-installation).
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -361,6 +361,9 @@ systemctl status wof
 If you want to see the data of Wall of Flippers on you Pwnagotchi screen, install CyberArtemio's `wof-pwnagotchi-plugin`. Follow the installation steps [here](https://github.com/cyberartemio/wof-pwnagotchi-plugin#-installation).
 
 </details>
+
+# Issues and Fixes <a name = "doc_issues_and_fixes"></a>
+
 > If you encounter any issues or bugs, please report them to us on our github page. We will try our best to fix them as soon as possible. If you would like to contribute to the project, please feel free to make a pull request. We will review it and merge it if it is a good addition to the project. We will be starting a discord server soon for support and development. Please keep an eye out for that. Thank you for your support and we hope you enjoy this project! <3
 
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@
     	- [Arch Linux Install (SOON)](#arch_install)
     	- [PinePhone Install (SOON)](#pinephone_install)
   	    - [Windows Install](#windows_install)
+		- [Pwnagotchi](#pwnagotchi)
 - [Issues and Fixes](#doc_issues_and_fixes)
 - [Common Errors and Fixes](#doc_c_and_e)
 - [Notice](#doc_statement)
@@ -316,7 +317,7 @@ python3 -m venv .venv && source .venv/bin/activate && pip install -r requirement
 ```
 
 #### Step 3: Systemd daemon
-Create a file in `/etc/systemd/system` and add:
+Create the systemd service in `/etc/systemd/system/wof.service` and add:
 ```
 [Unit]
 Description=WallofFlippers - A simple and easy way to find Flipper Zero Devices and Bluetooth Low Energy Based Attacks

--- a/README.md
+++ b/README.md
@@ -298,7 +298,68 @@ https://stackoverflow.com/questions/23708898/pip-is-not-recognized-as-an-interna
 
 </details>
 
-# Issues and Fixes <a name = "doc_issues_and_fixes"></a>
+<details>
+<summary>Pwnagotchi</summary>
+
+### Pwnagotchi
+You can run Wall of Flippers on Pwnagotchi to scan and save flippers data that your little friend find near them.
+
+#### Step 1: Clone the repo
+Login as `root` on your Pwnagotchi and run:
+```
+cd /root && git clone https://www.github.com/K3YOMI/Wall-of-Flippers && cd Wall-of-Flippers
+```
+
+#### Step 2: Install Python dependencies
+```
+python3 -m venv .venv && source .venv/bin/activate && pip install -r requirements.txt
+```
+
+#### Step 3: Systemd daemon
+Create a file in `/etc/systemd/system` and add:
+```
+[Unit]
+Description=WallofFlippers - A simple and easy way to find Flipper Zero Devices and Bluetooth Low Energy Based Attacks
+
+[Service]
+ExecStart=/root/Wall-of-Flippers/.venv/bin/python /root/Wall-of-Flippers/WallofFlippers.py wof -d 0
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=wof
+User=root
+Group=root
+Environment="PYTHONUNBUFFERED=1"
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Then run:
+```
+systemctl daemon-reload
+```
+
+#### Step 4: Start daemon
+To start Wall of Flippers daemon, run:
+```
+systemctl start wof
+```
+
+If you want to start the daemon on boot, run:
+```
+systemctl enable wof
+```
+
+Once you start the daemon, Wall of Flippers should be running and scanning for nearby Flippers. You can check the status by running:
+```
+systemctl status wof
+```
+
+#### Step 5: Install plugin (optional)
+
+If you want to see the data of Wall of Flippers on you Pwnagotchi screen, install CyberArtemio's `wof-pwnagotchi-plugin`. Follow the installation steps [here](https://github.com/cyberartemio/wof-pwnagotchi-plugin#-installation).
+
+</details>
 > If you encounter any issues or bugs, please report them to us on our github page. We will try our best to fix them as soon as possible. If you would like to contribute to the project, please feel free to make a pull request. We will review it and merge it if it is a good addition to the project. We will be starting a discord server soon for support and development. Please keep an eye out for that. Thank you for your support and we hope you enjoy this project! <3
 
 

--- a/WallofFlippers.py
+++ b/WallofFlippers.py
@@ -297,6 +297,7 @@ if args.action == "wof":
 elif args.action is None:
     # If no action is specified, run interactive selection
     selection_box = library.init()
+    device_hci = None
 
 if selection_box in ("wall_of_flippers", "capture_the_flippers"):
     try:

--- a/WallofFlippers.py
+++ b/WallofFlippers.py
@@ -29,8 +29,6 @@ import shutil
 import time
 import asyncio
 import json
-import random
-
 
 # Wall of Flippers Imports
 import utils.wof_cache as cache # for important configurations and data :3

--- a/WallofFlippers.py
+++ b/WallofFlippers.py
@@ -165,7 +165,6 @@ def sort_packets(ble_packets:list):
         print("[!] Wall of Flippers >> Error: Type not supported")
     cache.wof_data['bool_isScanning'] = False
 
-
 async def detection_async(os_param:str, detection_type=0): # renamed 'os' and 'type' to avoid conflict with built-in functions. Feel free to change it to something more appropriate as I'm not exactly sure what they do
     """BLE detection"""
     try:
@@ -253,27 +252,6 @@ async def detection_async(os_param:str, detection_type=0): # renamed 'os' and 't
 
 # Start of the program
 library.check_json_file_exist()
-os.system('cls' if os.name == 'nt' else 'clear')
-
-cache.wof_data['system_type'] = os.name
-
-if cache.wof_data['system_type'] == "posix": # Linux Auto Install
-    if not os.path.exists(".venv/bin/activate"): # Check if the user has setup their virtual environment
-        library.print_ascii_art("Uh oh, it seems like you have not setup your virtual environment yet!")
-        print("[!] Wall of Flippers >> It seems like you have not setup your virtual environment yet.\n\t      Reason: .venv/bin/activate does not exist.")
-        print("[!] Wall of Flippers >> Would you like to setup your virtual environment now?")
-        if input("[?] Wall of Flippers (Y/N) >> ").lower() == "y":
-            os.system("python3 -m venv .venv")
-            print("[!] Wall of Flippers >> Virtual environment setup successfully!")
-            sys.exit()
-    if library.is_in_venv() == False: # Check if the user is in their virtual environment
-        library.print_ascii_art("Uh oh, it seems like you are not in your virtual environment!")
-        print("[!] Wall of Flippers >> It seems like you are not in your virtual environment. Please use the following command to enter your virtual environment.")
-        print("\tsource .venv/bin/activate")
-        print("\tor")
-        print("\tbash wof.sh")
-        sys.exit()
-
 # Command args parsing 
 parser = argparse.ArgumentParser(prog = "WallofFlippers.py")
 base_parser = argparse.ArgumentParser(add_help=False)
@@ -283,6 +261,32 @@ wof_parser = subparsers.add_parser("wof", help="Run WoF: scan for nearby online 
 wof_parser.add_argument("-d", "--device", help="Index of HCI device to use for scanning", required=True)
 
 args = parser.parse_args()
+
+cache.wof_data['no_ui'] = args.no_ui
+
+if not cache.wof_data['no_ui']:
+    os.system('cls' if os.name == 'nt' else 'clear')
+
+cache.wof_data['system_type'] = os.name
+
+if cache.wof_data['system_type'] == "posix": # Linux Auto Install
+    if not os.path.exists(".venv/bin/activate"): # Check if the user has setup their virtual environment
+        library.print_ascii_art("Uh oh, it seems like you have not setup your virtual environment yet!")
+        print("[!] Wall of Flippers >> It seems like you have not setup your virtual environment yet.\n\t      Reason: .venv/bin/activate does not exist.")
+        if not cache.wof_data['no_ui']:
+            print("[!] Wall of Flippers >> Would you like to setup your virtual environment now?")
+            if input("[?] Wall of Flippers (Y/N) >> ").lower() == "y":
+                os.system("python3 -m venv .venv")
+                print("[!] Wall of Flippers >> Virtual environment setup successfully!")
+                sys.exit()
+    if library.is_in_venv() == False: # Check if the user is in their virtual environment
+        library.print_ascii_art("Uh oh, it seems like you are not in your virtual environment!")
+        print("[!] Wall of Flippers >> It seems like you are not in your virtual environment. Please use the following command to enter your virtual environment.")
+        print("\tsource .venv/bin/activate")
+        print("\tor")
+        print("\tbash wof.sh")
+        sys.exit()
+
 if args.action == "wof":
     selection_box = "wall_of_flippers"
     device_hci = args.device
@@ -314,7 +318,6 @@ if selection_box == 'wall_of_flippers':
         sys.exit()
     try:
         if device_hci is None: # device_hci is already set if wof is runned using args
-            ble_adapters = []
             if cache.wof_data['system_type'] == "posix":
                 ble_adapters = [adapter for adapter in os.listdir('/sys/class/bluetooth/') if 'hci' in adapter]
                 # make a selection of the bluetooth adapter

--- a/WallofFlippers.py
+++ b/WallofFlippers.py
@@ -336,8 +336,10 @@ if selection_box == 'wall_of_flippers':
                 asyncio.run(detection_async(cache.wof_data['system_type'], device_hci))
             time.sleep(1)
     except KeyboardInterrupt:
-        library.print_ascii_art("Thank you for using Wall of Flippers... Goodbye!")
-        print("\n[!] Wall of Flippers >> Exiting...")
+        if not cache.wof_data['no_ui']:
+            library.print_ascii_art("Thank you for using Wall of Flippers... Goodbye!")
+            print("\n")
+        print("[!] Wall of Flippers >> Exiting...")
         sys.exit()
 
 if selection_box == 'capture_the_flippers': # todo: needs to be updated for narrow mode compatibility

--- a/WallofFlippers.py
+++ b/WallofFlippers.py
@@ -203,7 +203,7 @@ async def detection_async(os_param:str, detection_type=0): # renamed 'os' and 't
                 cache.wof_data['bool_isScanning'] = False
         elif os_param == "posix": # Linux Detection
             scanner = Scanner(detection_type) # Thank you Talking Sasquach for testing this!
-            devices = scanner.scan(5) # Scan the area for 5 seconds....
+            devices = scanner.scan(5, passive = True) # Scan the area for 5 seconds....
             if devices:
                 for device in devices:
                     scan_list = device.getScanData()
@@ -246,9 +246,9 @@ async def detection_async(os_param:str, detection_type=0): # renamed 'os' and 't
             cache.wof_data['bool_isScanning'] = False
         sort_packets(ble_packets)
     except Exception as e:
+        cache.wof_data['bool_isScanning'] = False
         library.print_ascii_art("Error: Failed to scan for BLE devices")
         print("[!] Wall of Flippers >> Error: Failed to scan for BLE devices >> " + str(e))
-        sys.exit()
 
 # Start of the program
 library.check_json_file_exist()
@@ -336,9 +336,7 @@ if selection_box == 'wall_of_flippers':
                 asyncio.run(detection_async(cache.wof_data['system_type'], device_hci))
             time.sleep(1)
     except KeyboardInterrupt:
-        if not cache.wof_data['no_ui']:
-            library.print_ascii_art("Thank you for using Wall of Flippers... Goodbye!")
-            print("\n")
+        library.print_ascii_art("Thank you for using Wall of Flippers... Goodbye!")
         print("[!] Wall of Flippers >> Exiting...")
         sys.exit()
 

--- a/WallofFlippers.py
+++ b/WallofFlippers.py
@@ -256,7 +256,7 @@ library.check_json_file_exist()
 parser = argparse.ArgumentParser(prog = "WallofFlippers.py")
 base_parser = argparse.ArgumentParser(add_help=False)
 subparsers = parser.add_subparsers(dest="action", help="Skip interactive ui and just run selected mode")
-parser.add_argument('--no-ui', action="store_true", default=False, help="Disable ui") # TODO: currently not used
+parser.add_argument('--no-ui', action="store_true", default=False, help="Disable ui")
 wof_parser = subparsers.add_parser("wof", help="Run WoF: scan for nearby online flippers", parents=[base_parser])
 wof_parser.add_argument("-d", "--device", help="Index of HCI device to use for scanning", required=True)
 

--- a/utils/wof_bleexploitation.py
+++ b/utils/wof_bleexploitation.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python3
-
 #                               YAao,                            
 #                                 Y8888b,                        Created By: Kiyomi + Emilia (jbohack)
 #                               ,oA8888888b,                     Emilia: https://ko-fi.com/emilia0001

--- a/utils/wof_cache.py
+++ b/utils/wof_cache.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python3
-
 #                               YAao,                            
 #                                 Y8888b,                        Created By: Kiyomi + Emilia (jbohack)
 #                               ,oA8888888b,                     Emilia: https://ko-fi.com/emilia0001

--- a/utils/wof_cache.py
+++ b/utils/wof_cache.py
@@ -102,4 +102,5 @@ wof_data = {
     "ascii_normal": open('./ascii/normal.txt', 'r', encoding="utf-8").read().encode("ascii", "ignore").decode("ascii"),
     "ascii_ctf_normal": open('./ascii/ctf_normal.txt', 'r', encoding="utf-8").read().encode("ascii", "ignore").decode("ascii"),
     "ascii_small": open('./ascii/small.txt', 'r', encoding="utf-8").read().encode("ascii", "ignore").decode("ascii"),
+    "no_ui": False # Set to "True" when running in background (no active terminal)
 }

--- a/utils/wof_capture.py
+++ b/utils/wof_capture.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python3
-
 #                               YAao,                            
 #                                 Y8888b,                        Created By: Kiyomi + Emilia (jbohack)
 #                               ,oA8888888b,                     Emilia: https://ko-fi.com/emilia0001

--- a/utils/wof_display.py
+++ b/utils/wof_display.py
@@ -28,8 +28,7 @@ import shutil
 import utils.wof_cache as cache # Wall of Flippers "cache" for important configurations and data :3
 import utils.wof_library as library # Wall of Flippers "library" for important functions and classes :3
 
-
-def display(custom_text:str=None):
+def __update_screen(custom_text=None):
     """displays the data in a nice format"""
 
     # Load flipper data from Flipper.json
@@ -182,3 +181,12 @@ def display(custom_text:str=None):
     cache.wof_data['all_packets_found'] = []
     cache.wof_data['duplicated_packets'] = []
     cache.wof_data['base_flippers'] = []
+
+def __log(): # TODO: TBD
+    pass
+
+def display(custom_text:str=None):
+    if not cache.wof_data['no_ui']:
+        __update_screen(custom_text=custom_text)
+    else:
+        __log()

--- a/utils/wof_display.py
+++ b/utils/wof_display.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python3
-
 #                               YAao,                            
 #                                 Y8888b,                        Created By: Kiyomi + Emilia (jbohack)
 #                               ,oA8888888b,                     Emilia: https://ko-fi.com/emilia0001

--- a/utils/wof_display.py
+++ b/utils/wof_display.py
@@ -182,8 +182,25 @@ def __update_screen(custom_text=None):
     cache.wof_data['duplicated_packets'] = []
     cache.wof_data['base_flippers'] = []
 
-def __log(): # TODO: TBD
-    pass
+last_log_online_flippers = [] # MAC addresses of Flippers that were online in the last log
+def __log():
+    global last_log_online_flippers
+    online_flippers = [ flipper for flipper in cache.wof_data["found_flippers"] if flipper["MAC"] in cache.wof_data["live_flippers"] and flipper["MAC"] not in last_log_online_flippers ]
+    offline_flippers = [ flipper for flipper in cache.wof_data["found_flippers"] if flipper["MAC"] not in cache.wof_data["live_flippers"] and flipper["MAC"] in last_log_online_flippers ]
+    
+    for flipper in online_flippers:
+        print(f'[!] Wall of Flippers >> {flipper["Name"]} [{flipper["MAC"]}] is online')
+    for flipper in offline_flippers:
+        print(f'[!] Wall of Flippers >> {flipper["Name"]} [{flipper["MAC"]}] is offline')
+
+    cache.wof_data['display_live'] = []
+    cache.wof_data['display_offline'] = []
+    last_log_online_flippers = cache.wof_data['live_flippers']
+    cache.wof_data['live_flippers'] = []
+    cache.wof_data['forbidden_packets_found'] = []
+    cache.wof_data['all_packets_found'] = []
+    cache.wof_data['duplicated_packets'] = []
+    cache.wof_data['base_flippers'] = []
 
 def display(custom_text:str=None):
     if not cache.wof_data['no_ui']:

--- a/utils/wof_display.py
+++ b/utils/wof_display.py
@@ -24,7 +24,6 @@
 
 # Standard library Imports
 import json
-import os
 import shutil
 
 # Wall of Flippers "library" for important functions and classes :3

--- a/utils/wof_install.py
+++ b/utils/wof_install.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python3
-
 #                               YAao,                            
 #                                 Y8888b,                        Created By: Kiyomi + Emilia (jbohack)
 #                               ,oA8888888b,                     Emilia: https://ko-fi.com/emilia0001

--- a/utils/wof_install.py
+++ b/utils/wof_install.py
@@ -23,7 +23,6 @@
 
 
 # Standard library Imports
-import platform
 import os
 import sys
 import json

--- a/utils/wof_library.py
+++ b/utils/wof_library.py
@@ -83,20 +83,20 @@ def print_ascii_art(custom_text:str = None):
     if not cache.wof_data['no_ui']:
         os.system('cls' if os.name == 'nt' else 'clear')
     
-    r_quote = random.choice(cache.wof_data['dolphin_thinking']) if not custom_text else custom_text
+        r_quote = random.choice(cache.wof_data['dolphin_thinking']) if not custom_text else custom_text
 
-    # selecting adequate ASCII art based on the terminal size and if the user is in Capture The Flippers mode
-    print("\033[0;94m")
-    if cache.wof_data['narrow_mode']:
-        print(cache.wof_data['ascii_small'])
-        print(f"\"{r_quote}\"".center(50))
-        print("\033[0m")
-    else:
-        if is_in_ctf(): # If the user is in Capture The Flippers mode, then display the Capture The Flippers ASCII art
-            print(cache.wof_data['ascii_ctf_normal'].replace("[RANDOM_QUOTE]", r_quote))
-        else :
-            print(cache.wof_data['ascii_normal'].replace("[RANDOM_QUOTE]", r_quote))
-        print("\033[0m\n")
+        # selecting adequate ASCII art based on the terminal size and if the user is in Capture The Flippers mode
+        print("\033[0;94m")
+        if cache.wof_data['narrow_mode']:
+            print(cache.wof_data['ascii_small'])
+            print(f"\"{r_quote}\"".center(50))
+            print("\033[0m")
+        else:
+            if is_in_ctf(): # If the user is in Capture The Flippers mode, then display the Capture The Flippers ASCII art
+                print(cache.wof_data['ascii_ctf_normal'].replace("[RANDOM_QUOTE]", r_quote))
+            else :
+                print(cache.wof_data['ascii_normal'].replace("[RANDOM_QUOTE]", r_quote))
+            print("\033[0m\n")
 
 def init():
     """Initial Selection Box (Upon starup)

--- a/utils/wof_library.py
+++ b/utils/wof_library.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python3
-
 #                               YAao,                            
 #                                 Y8888b,                        Created By: Kiyomi + Emilia (jbohack)
 #                               ,oA8888888b,                     Emilia: https://ko-fi.com/emilia0001

--- a/utils/wof_library.py
+++ b/utils/wof_library.py
@@ -80,7 +80,9 @@ def is_in_venv():
 
 def print_ascii_art(custom_text:str = None):
     """Displays ASCII art in the terminal with the custom text if provided, otherwise displays a random quote"""
-    os.system('cls' if os.name == 'nt' else 'clear')
+    if not cache.wof_data['no_ui']:
+        os.system('cls' if os.name == 'nt' else 'clear')
+    
     r_quote = random.choice(cache.wof_data['dolphin_thinking']) if not custom_text else custom_text
 
     # selecting adequate ASCII art based on the terminal size and if the user is in Capture The Flippers mode


### PR DESCRIPTION
I added the ability to run the `wall_of_flippers` mode directly from the invocation without having to use the interactive ui.

The reason I made this change is to be able to run Wall of Flippers in the background as a systemd process. Mainly I did it so that it is possible to run the script on Pwnagotchi then using the plugin I made to see the name of the Flipper on the display, but the same thing can be done on any Linux system (except for the plugin of course).

I also added the instructions in the README about installing on the pwnagotchi trying to follow the current style.

For now the only mode that is possible to invoke from the command line is the `wall_of_flippers` mode, but it should be quick to add the other modes as well.

Last thing: when in no-ui mode all banner printing is disabled and only logged when a Flipper device changes from offline to online and vice versa, this is because the logs are looked at periodically.

I tried to touch as little of the existing code as possible, adding only the bare minimum.