### PR TITLE
added a RSSI value column for the BLE spam packets

### DIFF
--- a/utils/wof_display.py
+++ b/utils/wof_display.py
@@ -118,14 +118,15 @@ def display(custom_text:str=None):
             # Display forbidden packets
             if len(cache.wof_data['forbidden_packets_found']) > 0:
                 t_packets = 0
-                print("\n\n[!] Wall of Flippers >> These packets may not be related to the Flipper Zero.\n[NAME]\t\t\t\t\t[ADDR]\t\t   [PACKET]")
+                print("\n\n[!] Wall of Flippers >> These packets may not be related to the Flipper Zero.\n[NAME]\t\t\t\t\t[RSSI]\t[ADDR]\t\t   [PACKET]")
                 print(shutil.get_terminal_size().columns * "-")
                 for key in cache.wof_data['forbidden_packets_found']:
                     if ble_spamming_macs.count(key['MAC']) == 0:
                         ble_spamming_macs.append(key['MAC'])
                         t_packets += 1
                         if t_packets <= cache.wof_data['max_ble_packets']: # Max amount of packets to display on the screen
-                            print(f"{key['Type'].ljust(t_allignment)}\t\t{key['MAC'].ljust(t_allignment)}  {key['PCK'].ljust(t_allignment)}")
+                            rssi_value = str(key.get('RSSI', 'N/A'))
+                            print(f"{key['Type'].ljust(t_allignment)}\t\t{rssi_value.ljust(t_allignment)}{key['MAC'].ljust(t_allignment)}  {str(key['PCK']).ljust(t_allignment)}")
                 if number_of_total_blacklisted_packets > cache.wof_data['ble_threshold']:
                     print(f"------------------ Bluetooth Low Energy (BLE) Attacks Detected ({number_of_total_blacklisted_packets} Advertisements) --------------------")
     else: # if the system is not POSIX (Windows)

--- a/utils/wof_library.py
+++ b/utils/wof_library.py
@@ -112,7 +112,7 @@ def ble2Sort(packets:list): # Sorts BLE packets and updates the list/cache
                     int_get_non_underscore = len(forbidden_packet['PCK'].replace("_", ""))
                     int_total_found = sum(p != "_" for p in packet)
                     if int_total_found >= int_get_non_underscore:
-                        cache.wof_data['forbidden_packets_found'].append({"Type": forbidden_packet['TYPE'],"PCK": packet,"MAC": adv_address})
+                        cache.wof_data['forbidden_packets_found'].append({"Type": forbidden_packet['TYPE'],"PCK": packet,"MAC": adv_address, "RSSI": adv_rssi})
                 if len(packet) > cache.wof_data['min_byte_length']: # If the packet is longer than the minimum byte length, then it is a valid packet we want to log
                     cache.wof_data['all_packets_found'].append({"PCK": packet,"MAC": adv_address})
             if str(packet).startswith(wof_advertiserRaw):


### PR DESCRIPTION
If flippers do not have Bluetooth enabled, they cannot be tracked by RSSI. I added a RSSI column to the BLE spam packets so that they could attributed to the device transmitting them.

![blespamrssi](https://github.com/user-attachments/assets/2369447e-7b42-47e4-b290-2d84bedf18f5)
